### PR TITLE
id が不正な値の場合でも、エラーを返していなかったのを修正

### DIFF
--- a/lib/JSON/RPC/Spec/Procedure.pm
+++ b/lib/JSON/RPC/Spec/Procedure.pm
@@ -25,6 +25,10 @@ sub parse {
         return $self->_rpc_invalid_request;
     }
     $self->_is_notification(!exists $obj->{id});
+    if (defined $obj->{id} and ref $obj->{id} ne '') {
+        $self->_id(undef);
+        return $self->_rpc_invalid_request;
+    }
     $self->_id($obj->{id});
     my $method = $obj->{method} || '';
 

--- a/t/json-rpc-2.0-exercises.t
+++ b/t/json-rpc-2.0-exercises.t
@@ -68,4 +68,42 @@ subtest 'invalid jsonrpc version 2' => sub {
       or diag explain $res;
 };
 
+subtest 'invalid id' => sub {
+    my $res;
+    $res = $rpc->parse_without_encode(
+        '{"jsonrpc":"2.0","method":"sum","params":[1,2],"id":{}}');
+    is ref $res, 'HASH';
+    ok exists $res->{error};
+    is_deeply $res,
+      {
+        "jsonrpc" => "2.0",
+        "error"   => {
+            "code"    => -32600,
+            "message" => "Invalid Request"
+        },
+        "id" => undef
+      },
+      'invalid id'
+      or diag explain $res;
+};
+
+subtest 'invalid id 2' => sub {
+    my $res;
+    $res = $rpc->parse_without_encode(
+        '{"jsonrpc":"2.0","method":"sum","params":[1,2],"id":false}');
+    is ref $res, 'HASH';
+    ok exists $res->{error};
+    is_deeply $res,
+      {
+        "jsonrpc" => "2.0",
+        "error"   => {
+            "code"    => -32600,
+            "message" => "Invalid Request"
+        },
+        "id" => undef
+      },
+      'invalid id'
+      or diag explain $res;
+};
+
 done_testing;

--- a/t/json-rpc-2.0-exercises.t
+++ b/t/json-rpc-2.0-exercises.t
@@ -143,13 +143,13 @@ subtest 'valid id(NULL)' => sub {
 subtest 'valid id(String)' => sub {
     my $res;
     $res = $rpc->parse_without_encode(
-        '{"jsonrpc":"2.0","method":"sum","params":[1,2],"id":"!""#$%&()"}');
+        '{"jsonrpc":"2.0","method":"sum","params":[1,2],"id":"!\"#$%&()"}');
     is ref $res, 'HASH';
     is_deeply $res,
       {
         jsonrpc => "2.0",
         result  => 3,
-        id      => undef
+        id      => q{!"#$%&()}
       },
       'valid id'
       or diag explain $res;

--- a/t/json-rpc-2.0-exercises.t
+++ b/t/json-rpc-2.0-exercises.t
@@ -68,7 +68,7 @@ subtest 'invalid jsonrpc version 2' => sub {
       or diag explain $res;
 };
 
-subtest 'invalid id' => sub {
+subtest 'invalid id(HASH)' => sub {
     my $res;
     $res = $rpc->parse_without_encode(
         '{"jsonrpc":"2.0","method":"sum","params":[1,2],"id":{}}');
@@ -87,7 +87,26 @@ subtest 'invalid id' => sub {
       or diag explain $res;
 };
 
-subtest 'invalid id 2' => sub {
+subtest 'invalid id(ARRAY)' => sub {
+    my $res;
+    $res = $rpc->parse_without_encode(
+        '{"jsonrpc":"2.0","method":"sum","params":[1,2],"id":[]}');
+    is ref $res, 'HASH';
+    ok exists $res->{error};
+    is_deeply $res,
+      {
+        "jsonrpc" => "2.0",
+        "error"   => {
+            "code"    => -32600,
+            "message" => "Invalid Request"
+        },
+        "id" => undef
+      },
+      'invalid id'
+      or diag explain $res;
+};
+
+subtest 'invalid id(BOOLEAN)' => sub {
     my $res;
     $res = $rpc->parse_without_encode(
         '{"jsonrpc":"2.0","method":"sum","params":[1,2],"id":false}');
@@ -103,6 +122,36 @@ subtest 'invalid id 2' => sub {
         "id" => undef
       },
       'invalid id'
+      or diag explain $res;
+};
+
+subtest 'valid id(NULL)' => sub {
+    my $res;
+    $res = $rpc->parse_without_encode(
+        '{"jsonrpc":"2.0","method":"sum","params":[1,2],"id":null}');
+    is ref $res, 'HASH';
+    is_deeply $res,
+      {
+        jsonrpc => "2.0",
+        result  => 3,
+        id      => undef
+      },
+      'valid id'
+      or diag explain $res;
+};
+
+subtest 'valid id(String)' => sub {
+    my $res;
+    $res = $rpc->parse_without_encode(
+        '{"jsonrpc":"2.0","method":"sum","params":[1,2],"id":"!""#$%&()"}');
+    is ref $res, 'HASH';
+    is_deeply $res,
+      {
+        jsonrpc => "2.0",
+        result  => 3,
+        id      => undef
+      },
+      'valid id'
       or diag explain $res;
 };
 


### PR DESCRIPTION
id は JSON でいう String, Number, NULL が許容されている。
Request object の id の項には以下のように書かれている。
> An identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [[1]](https://www.jsonrpc.org/specification#id1) and Numbers SHOULD NOT contain fractional parts [[2]](https://www.jsonrpc.org/specification#id2)